### PR TITLE
Change all functions using args to use table.pack()

### DIFF
--- a/luadash.lua
+++ b/luadash.lua
@@ -17,16 +17,16 @@ end
 
 function _.partial(f, ...)
   _.expect('partial', 1, 'function', f)
-  local args = { ... }
+  local args = table.pack(...)
   return function(...)
-    local args2, actual, n = { ... }, { }, #args
-    for i = 1, n do
+    local args2, actual = table.pack(...), { }
+    for i = 1, args.n do
       actual[i] = args[i]
     end
-    for i = 1, #args2 do
+    for i = 1, args2.n do
       actual[n + i] = args2[i]
     end
-    return f(unpack(actual, 1, n + #args2))
+    return f(unpack(actual, 1, args.n + args2.n ))
   end
 end
 
@@ -65,15 +65,15 @@ end
 function _.map(t1, f, ...)
   _.expect('map', 1, 'table', t1)
   _.expect('map', 2, 'function', f)
-  local args, n = {t1, ...}, 0
-  for i = 1, #args do
+  local args, n = table.pack(t1, ...), 0
+  for i = 1, args.n do
     _.expect('map', 1 + i, 'table', args[i])
     n = math.max(n, #args[i])
   end
   local out = {}
   for i = 1, n do
     local these = {}
-    for j = 1, #args do
+    for j = 1, args.n do
       these[j] = args[j][i]
     end
     out[i] = _.apply(f, these)
@@ -82,8 +82,8 @@ function _.map(t1, f, ...)
 end
 
 function _.zip(...)
-  local args = {...}
-  for i = 1, #args do
+  local args = table.pack(...)
+  for i = 1, args.n do
     _.expect('zip', 1, 'table', args[i])
   end
   return _.map(function(...) return {...} end, ...)
@@ -91,8 +91,8 @@ end
 
 function _.push(t, ...)
   _.expect('push', 1, 'table', t)
-  local args = {...}
-  for i = 1, #args do
+  local args = table.pack(...)
+  for i = 1, args.n do
     table.insert(t, args[i])
   end
   return t
@@ -127,15 +127,15 @@ end
 function _.flat_map(t1, f, ...)
   _.expect('flat_map', 1, 'table', t1)
   _.expect('flat_map', 2, 'function', f)
-  local args, n = {t1, ...}, 0
-  for i = 1, #args do
+  local args, n = table.pack(t1, ...), 0
+  for i = 1, args.n do
     _.expect('map', 1 + i, 'table', args[i])
     n = math.max(n, #args[i])
   end
   local out, li = {}, 0
   for i = 1, n do
     local these = {}
-    for j = 1, #args do
+    for j = 1, args.n do
       these[j] = args[j][i]
     end
     local r = _.apply(f, these)


### PR DESCRIPTION
Due to not smart way # works in Lua 5.1 it is less iritating to use .n provided by table.pack().
Sorry for separate PR but i never claimed to be handy with git commands.