### PR TITLE
 Added string:startswith(string)

### DIFF
--- a/doc/startswith.txt
+++ b/doc/startswith.txt
@@ -1,0 +1,14 @@
+* string:startswith(string)
+
+  Returns if a string has a certain prefix.
+
+  Example:
+
+    local foo = "hello world"
+    print(foo:startswith("hello"))
+    print(foo:startswith("bar"))
+    print(foo:startswith(""))
+    
+    true
+    false
+    true

--- a/library.lua
+++ b/library.lua
@@ -293,8 +293,9 @@ _.ops = {
   ['<='] = function(a, b) return a <= b end,
 }
 
-string.startswith = function(self, str) 
-  return self:find('^' .. str) ~= nil
+function string.starts_with(self, s)
+  _.expect('starts_with', 1, 'string', s)
+  return self:find('^' .. s) ~= nil
 end
 
 return _

--- a/library.lua
+++ b/library.lua
@@ -294,7 +294,7 @@ _.ops = {
 }
 
 string.startswith = function(self, str) 
-    return self:find('^' .. str) ~= nil
+  return self:find('^' .. str) ~= nil
 end
 
 return _

--- a/library.lua
+++ b/library.lua
@@ -293,4 +293,8 @@ _.ops = {
   ['<='] = function(a, b) return a <= b end,
 }
 
+string.startswith = function(self, str) 
+    return self:find('^' .. str) ~= nil
+end
+
 return _


### PR DESCRIPTION
With this addition, there now exists a `startswith` function for strings.

Example:
```
local foo = "hello world"
print(foo:startswith("hello")) -- prints true
print(foo:startswith("bar")) -- prints false
print(foo:startswith("")) -- prints true
```