### PR TITLE
Implement clone

### DIFF
--- a/doc/clone.txt
+++ b/doc/clone.txt
@@ -1,6 +1,6 @@
 * _.clone(value)
 
-  Create a shallow copy by cloning 'value'.
+  Create a shallow copy of 'value'.
 
   Examples:
 

--- a/doc/clone.txt
+++ b/doc/clone.txt
@@ -1,0 +1,10 @@
+* _.clone(value)
+
+  Create a shallow copy by cloning 'value'.
+
+  Examples:
+
+    > _.clone({ 1, 2, 3 })
+    { 1, 2, 3 }
+    > _.clone({ a = 1, b = true, c = "c" })
+    { a = 1, c = "c", b = true }

--- a/library.lua
+++ b/library.lua
@@ -66,7 +66,7 @@ end
 
 function _.clone(value)
   if type(value) == 'table' then
-  local copy = {}
+    local copy = {}
     for k, v in pairs(value) do
       copy[k] = v
     end

--- a/library.lua
+++ b/library.lua
@@ -64,6 +64,19 @@ function _.apply(f, t)
   return f(table.unpack(t, 1, #t))
 end
 
+function _.clone(value)
+  local out
+  if type(value) == 'table' then
+    out = {}
+    for k, v in pairs(value) do
+      out[k] = v
+    end
+  else
+    out = value
+  end
+  return out
+end
+
 function _.map(t1, f, ...)
   _.expect('map', 1, 'table', t1)
   _.expect('map', 2, 'function', f)

--- a/library.lua
+++ b/library.lua
@@ -65,16 +65,14 @@ function _.apply(f, t)
 end
 
 function _.clone(value)
-  local out
   if type(value) == 'table' then
-    out = {}
+  local copy = {}
     for k, v in pairs(value) do
-      out[k] = v
+      copy[k] = v
     end
-  else
-    out = value
+    return copy
   end
-  return out
+  return value
 end
 
 function _.map(t1, f, ...)


### PR DESCRIPTION
Like [the lodash version](https://lodash.com/docs/4.17.10#clone), this returns a shallow copy of `value`. Not sure if more types should get some special handling.

Ideally, this would replace calls to `_.map(foo, _.id)` in [`sort_by`](https://github.com/tmpim/luadash/blob/57fdfa4c83c4cf2e2d40b27bf68dddd4b3838122/library.lua#L165) and #18.