### PR TITLE
Implement _.size

### DIFF
--- a/doc/size.txt
+++ b/doc/size.txt
@@ -1,0 +1,14 @@
+* _.size(t)
+
+  Returns the size of 't'. Accepts tables and strings.
+  Note that this function will not stop counting when
+  it hits a nil element, unlike the # operator.
+
+  Example:
+
+    > _.size({1, 2, 3}) 
+    3
+    > _.size({1, 2, nil, 3})
+    3
+    > _.size("abc")
+    3

--- a/library.lua
+++ b/library.lua
@@ -174,6 +174,21 @@ function _.sort(t)
   return _.sort_by(t, _.id)
 end
 
+function _.size(t)
+  local typ = type(t)
+  if typ == "table" then
+    local size = 0
+    for k,v in pairs(t) do
+      size = size + 1
+    end
+    return size
+  elseif typ == "string" then
+    return string.len(t)
+  else
+    error("cannot get the size of " .. typ)
+  end
+end
+
 function _.sample_size(t, n)
   _.expect('sample_size', 1, 'table', t)
   _.expect('sample_size', 2, 'number', n)
@@ -319,3 +334,4 @@ function string.starts_with(self, s)
 end
 
 return _
+


### PR DESCRIPTION
Similar to `_.size` in lodash. Counts the elements of tables or strings. Unlike `#`, it will count past `nil` elements, thus returning the true size of the table.